### PR TITLE
Minor, Rcpp 1.0.13 is not compatible with R >= 4.4.2

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -148,7 +148,7 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13",
+      "Version": "1.0.13-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [


### PR DESCRIPTION
Rcpp 1.0.13 is not compatible with R >= 4.4.2 issue https://github.com/RcppCore/Rcpp/issues/1341